### PR TITLE
Add fuzziness search defaulted to AUTO

### DIFF
--- a/config/laravel-search.php
+++ b/config/laravel-search.php
@@ -13,6 +13,8 @@ return [
 
     ],
 
+    'fuzziness' => env('SEARCH_FUZZINESS', 'AUTO'),
+
     'es' => [
         'user' => env('SEARCH_USER', ''),
         'password' => env('SEARCH_PASSWORD'),

--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -219,7 +219,6 @@ class ElasticSearchEngine extends EngineContract
                                 'multi_match' => [
                                     'query' => $builder->query,
                                     'fields' => $builder->fields,
-                                    'type' => 'phrase',
                                     'operator' => 'and',
                                     'fuzziness' => config('laravel-search.fuzziness'),
                                 ],
@@ -283,7 +282,6 @@ class ElasticSearchEngine extends EngineContract
                 'query' => [
                     'query_string' => [
                         'query' => $builder->query,
-                        'type' => 'phrase',
                         'default_operator' => 'and',
                         'fuzziness' => config('laravel-search.fuzziness'),
                     ],

--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -216,10 +216,10 @@ class ElasticSearchEngine extends EngineContract
                     'bool' => [
                         'must' => [
                             [
-                                'multi_match' => [
+                                'query_string' => [
                                     'query' => $builder->query,
                                     'fields' => $builder->fields,
-                                    'operator' => 'and',
+                                    'default_operator' => 'and',
                                     'fuzziness' => config('laravel-search.fuzziness'),
                                 ],
                             ]

--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -221,6 +221,7 @@ class ElasticSearchEngine extends EngineContract
                                     'fields' => $builder->fields,
                                     'type' => 'phrase',
                                     'operator' => 'and',
+                                    'fuzziness' => config('laravel-search.fuzziness'),
                                 ],
                             ]
                         ]
@@ -284,6 +285,7 @@ class ElasticSearchEngine extends EngineContract
                         'query' => $builder->query,
                         'type' => 'phrase',
                         'default_operator' => 'and',
+                        'fuzziness' => config('laravel-search.fuzziness'),
                     ],
                 ]
             ]

--- a/src/SearchServiceProvider.php
+++ b/src/SearchServiceProvider.php
@@ -43,6 +43,16 @@ class SearchServiceProvider extends ServiceProvider
     }
 
     /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->configurePublishing();
+    }
+
+    /**
      * Get the services provided by the provider.
      *
      * @return array
@@ -50,5 +60,21 @@ class SearchServiceProvider extends ServiceProvider
     public function provides()
     {
         return ['search'];
+    }
+
+    /**
+     * Configure publishing for the package.
+     *
+     * @return void
+     */
+    protected function configurePublishing()
+    {
+        if (!$this->app->runningInConsole()) {
+            return;
+        }
+
+        $this->publishes([
+            __DIR__ . '/../config/laravel-search.php' => config_path('laravel-search.php'),
+        ], 'laravel-search-config');
     }
 }


### PR DESCRIPTION
AUTO

Generates an edit distance based on the length of the term. Low and high distance arguments may be optionally provided `AUTO:[low],[high]`. If not specified, the default values are 3 and 6, equivalent to `AUTO:3,6` that make for lengths:

```
0..2
Must match exactly
3..5
One edit allowed
>5
Two edits allowed
AUTO should generally be the preferred value for fuzziness.
```

Added the ability to publish the config from vendor folder to config folder